### PR TITLE
Improve duplicate handling and add CLI

### DIFF
--- a/duplicate_finder.py
+++ b/duplicate_finder.py
@@ -5,7 +5,9 @@ class DuplicateFinder:
     def __init__(self, spotify_client: SpotifyClient):
         self.spotify_client = spotify_client
 
-    def find_cross_playlist_duplicates(self, playlists: List[Tuple[str, str]]) -> Dict[str, List[Dict]]:
+    def find_cross_playlist_duplicates(
+        self, playlists: List[Tuple[str, str]]
+    ) -> Dict[str, List[Dict[str, str]]]:
         """Find duplicate tracks across multiple playlists"""
         track_locations = {}
         
@@ -23,8 +25,9 @@ class DuplicateFinder:
                 
                 track_locations[track_id].append({
                     'playlist_name': playlist_name,
+                    'playlist_id': playlist_id,
                     'track_name': track_name,
-                    'artists': artists
+                    'artists': artists,
                 })
         
         # Filter out tracks that are not duplicates

--- a/playlist_cleaner.py
+++ b/playlist_cleaner.py
@@ -5,7 +5,9 @@ class PlaylistCleaner:
     def __init__(self, spotify_client: SpotifyClient):
         self.spotify_client = spotify_client
 
-    def remove_duplicates(self, duplicates: Dict[str, List[Dict]], keep_playlist_id: str):
+    def remove_duplicates(
+        self, duplicates: Dict[str, List[Dict[str, str]]], keep_playlist_id: str
+    ) -> None:
         """Remove duplicate tracks from playlists except the one to keep"""
         for track_id, locations in duplicates.items():
             for location in locations:


### PR DESCRIPTION
## Summary
- include playlist ID when tracking duplicates
- improve playlist cleaner type hints
- add argparse CLI with interactive fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_684814f9b09c832d9b0728bc76f16f87