### PR TITLE
Add test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ A Python application to manage your Spotify playlists and remove duplicate track
    - Let you choose which playlist to keep duplicates in
    - Remove duplicates from other playlists
 
+## Running Tests
+
+The project includes a small suite of unit tests under the `tests/` directory. These tests verify the logic for interacting with the Spotify API and for removing duplicate tracks.
+
+Run them with Python's built-in `unittest` module:
+
+```bash
+python -m unittest
+```
+
+All required packages are already listed in `requirements.txt`; no extra dependencies such as `pytest` are needed.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.


### PR DESCRIPTION
## Summary
- document how to run tests with `python -m unittest`
- mention that no extra dependencies are required

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_684817aad850832db22cc41804c28018