### PR TITLE
Add dry-run option for duplicate removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ A Python application to manage your Spotify playlists and remove duplicate track
    - Let you choose which playlist to keep duplicates in
    - Remove duplicates from other playlists
 
+You can also run the `remove-duplicates` command directly. Add the `--dry-run`
+flag to preview the changes without modifying your playlists:
+
+```bash
+python main.py remove-duplicates --keep YOUR_PLAYLIST_ID --dry-run
+```
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/main.py
+++ b/main.py
@@ -83,6 +83,11 @@ def main() -> None:
         required=True,
         help="Playlist ID to keep duplicate tracks in",
     )
+    clean_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only show which tracks would be removed",
+    )
 
     args = parser.parse_args()
 
@@ -109,7 +114,11 @@ def main() -> None:
     elif args.command == "remove-duplicates":
         playlists = spotify_client.get_user_playlists()
         duplicates = duplicate_finder.find_cross_playlist_duplicates(playlists)
-        playlist_cleaner.remove_duplicates(duplicates, args.keep)
+        playlist_cleaner.remove_duplicates(
+            duplicates,
+            args.keep,
+            dry_run=args.dry_run,
+        )
         print("Duplicates removed")
     else:
         interactive_flow(spotify_client, duplicate_finder, playlist_cleaner)

--- a/playlist_cleaner.py
+++ b/playlist_cleaner.py
@@ -6,14 +6,34 @@ class PlaylistCleaner:
         self.spotify_client = spotify_client
 
     def remove_duplicates(
-        self, duplicates: Dict[str, List[Dict[str, str]]], keep_playlist_id: str
+        self,
+        duplicates: Dict[str, List[Dict[str, str]]],
+        keep_playlist_id: str,
+        dry_run: bool = False,
     ) -> None:
-        """Remove duplicate tracks from playlists except the one to keep"""
+        """Remove duplicate tracks from playlists except the one to keep
+
+        Parameters
+        ----------
+        duplicates : Dict[str, List[Dict[str, str]]]
+            Mapping of track IDs to their playlist locations.
+        keep_playlist_id : str
+            Playlist ID in which duplicates should be kept.
+        dry_run : bool, optional
+            When ``True`` only print the actions without removing tracks.
+        """
         for track_id, locations in duplicates.items():
             for location in locations:
                 playlist_name = location['playlist_name']
                 playlist_id = location['playlist_id']
-                
+
                 if playlist_id != keep_playlist_id:
-                    print(f"Removing track from playlist: {playlist_name}")
-                    self.spotify_client.remove_tracks_from_playlist(playlist_id, [{'uri': f'spotify:track:{track_id}'}])
+                    message = f"Removing track from playlist: {playlist_name}"
+                    if dry_run:
+                        print(f"[Dry run] {message}")
+                        continue
+                    print(message)
+                    self.spotify_client.remove_tracks_from_playlist(
+                        playlist_id,
+                        [{'uri': f'spotify:track:{track_id}'}],
+                    )

--- a/tests/test_playlist_cleaner.py
+++ b/tests/test_playlist_cleaner.py
@@ -22,5 +22,17 @@ class TestPlaylistCleaner(unittest.TestCase):
             '2', [{'uri': 'spotify:track:track1'}]
         )
 
+    def test_remove_duplicates_dry_run(self):
+        duplicates = {
+            'track1': [
+                {'playlist_name': 'Playlist 1', 'playlist_id': '1'},
+                {'playlist_name': 'Playlist 2', 'playlist_id': '2'}
+            ]
+        }
+
+        self.playlist_cleaner.remove_duplicates(duplicates, '1', dry_run=True)
+
+        self.mock_spotify_client.remove_tracks_from_playlist.assert_not_called()
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
## Summary
- add `--dry-run` option to `remove-duplicates` CLI
- implement `dry_run` argument in `PlaylistCleaner.remove_duplicates`
- document new flag in README
- test dry run behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_684817a57b6c832d97e25a006890fc58