### PR TITLE
Add input validation for playlist selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,11 @@ def interactive_flow(
                     print(f"- {loc['playlist_name']}")
             
             # Ask user which playlist to keep duplicates in
-            keep_idx = int(input("\nWhich playlist would you like to keep the tracks in? (Enter number): ")) - 1
+            try:
+                keep_idx = int(input("\nWhich playlist would you like to keep the tracks in? (Enter number): ")) - 1
+            except ValueError:
+                print("\nPlease enter a valid number.")
+                return
             
             if 0 <= keep_idx < len(playlists):
                 keep_playlist_name, keep_playlist_id = playlists[keep_idx]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from main import interactive_flow
+from spotify_client import SpotifyClient
+from duplicate_finder import DuplicateFinder
+from playlist_cleaner import PlaylistCleaner
+
+class TestInteractiveFlow(unittest.TestCase):
+    def test_invalid_input_does_not_crash(self):
+        spotify_client = MagicMock(spec=SpotifyClient)
+        duplicate_finder = MagicMock(spec=DuplicateFinder)
+        playlist_cleaner = MagicMock(spec=PlaylistCleaner)
+
+        # Prepare mocks
+        spotify_client.get_user_playlists.return_value = [('Playlist 1', '1')]
+        duplicate_finder.find_cross_playlist_duplicates.return_value = {
+            'track1': [
+                {
+                    'playlist_name': 'Playlist 1',
+                    'playlist_id': '1',
+                    'track_name': 'Song 1',
+                    'artists': 'Artist'
+                }
+            ]
+        }
+
+        with patch('builtins.input', return_value='abc'), patch('builtins.print') as mock_print:
+            interactive_flow(spotify_client, duplicate_finder, playlist_cleaner)
+            mock_print.assert_any_call("\nPlease enter a valid number.")
+        playlist_cleaner.remove_duplicates.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle invalid numeric input in interactive flow
- test that non-numeric user input prints a helpful error and doesn't crash

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'spotipy')*
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_68481b9dd904832dbf1cb96e3f169f2c