### PR TITLE
Handle missing track info in duplicate finder

### DIFF
--- a/duplicate_finder.py
+++ b/duplicate_finder.py
@@ -16,9 +16,16 @@ class DuplicateFinder:
             tracks = self.spotify_client.get_playlist_tracks(playlist_id)
             
             for track in tracks:
-                track_id = track['track']['id']
-                track_name = track['track']['name']
-                artists = ', '.join(artist['name'] for artist in track['track']['artists'])
+                track_info = track.get('track')
+                if not track_info or not track_info.get('id'):
+                    # Skip entries without track details or an ID
+                    continue
+
+                track_id = track_info['id']
+                track_name = track_info.get('name', '')
+                artists = ', '.join(
+                    artist.get('name', '') for artist in track_info.get('artists', [])
+                )
                 
                 if track_id not in track_locations:
                     track_locations[track_id] = []

--- a/tests/test_duplicate_finder.py
+++ b/tests/test_duplicate_finder.py
@@ -21,5 +21,17 @@ class TestDuplicateFinder(unittest.TestCase):
         self.assertIn('track1', duplicates)
         self.assertEqual(len(duplicates['track1']), 2)
 
+    def test_find_cross_playlist_duplicates_with_missing_id(self):
+        playlists = [('Playlist 1', '1')]
+        # Track missing an ID and a None track
+        self.mock_spotify_client.get_playlist_tracks.return_value = [
+            {'track': {'id': None, 'name': 'Song 1', 'artists': [{'name': 'Artist 1'}]}},
+            {'track': None}
+        ]
+
+        duplicates = self.duplicate_finder.find_cross_playlist_duplicates(playlists)
+
+        self.assertEqual(duplicates, {})
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
## Summary
- skip tracks missing info when finding cross-playlist duplicates
- ensure missing IDs don't throw an error

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_68481ba7b6e8832dac9782d5d91540da