### PR TITLE
Add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Endpoints:
 
 See [docs/api.md](docs/api.md) for full details.
 
+## Testing
+
+Install the test dependencies using `pip`:
+
+```bash
+
+pip install -r requirements.txt
+```
+
+Run the test suite with:
+
+```bash
+pytest
+```
+
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document how to install test dependencies
- mention running pytest to execute tests

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68481d67b938832d9638d5b58596810c